### PR TITLE
Support python2 and 3, add file parse errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ Where possible, the tool will highlight where the statistics are outside the nor
 
 ![IRITopScreenshot](https://raw.githubusercontent.com/maeck70/iritop/master/img/IRITop.png)
 
+##Requirements
+
+Requirements can be installed via:
+
+```sh
+pip install -r requirements.txt
+```
+
 ##Usage:
 - Start without a --node argument will assume 'http://localhost:14265' as the node address for the web service calls.
 - Provide an address using --node http://myirinode:14265 if you want to specify a specific address.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # iritop
-##Simple Iota IRI Node Monitor
+
+##  Simple Iota IRI Node Monitor
 
 This is a simple monitor that runs from the command line. Typically this is run on the IRI node itself, however, as soon as the node is allowed to externally expose getNodeInfo and getNeighbors information, then this tool can be run from a remote shell as well.
 
@@ -11,20 +12,23 @@ Where possible, the tool will highlight where the statistics are outside the nor
 
 ![IRITopScreenshot](https://raw.githubusercontent.com/maeck70/iritop/master/img/IRITop.png)
 
-##Requirements
+## Requirements
 
-Requirements can be installed via:
+Requirements are listed in `requirements.txt` and can be automatically installed via:
 
 ```sh
 pip install -r requirements.txt
 ```
 
-##Usage:
-- Start without a --node argument will assume 'http://localhost:14265' as the node address for the web service calls.
-- Provide an address using --node http://myirinode:14265 if you want to specify a specific address.
+## Usage
 
-##Arguments:
-`  -h, --help            show this help message and exit
+- Start without a `--node` argument will assume 'http://localhost:14265' as the node address for the web service calls.
+- Provide an address using `--node http://myirinode:14265` if you want to specify a specific address.
+
+## Arguments
+
+```sh
+  -h, --help            show this help message and exit
   -v, --version         show program's version number and exit
   -c CONFIG, --config CONFIG
                         configuration file. Defaults to ~/.iritop
@@ -34,17 +38,18 @@ pip install -r requirements.txt
                         node poll delay. Default: 2s
   -b BLINK_DELAY, --blink-delay BLINK_DELAY
                         blink delay. Default: 0.5s
-`
+```
 
-The configuration can also be set in yaml formatted file. By default the configuration file from ~/.iritop is read. All configuration parameters can be provided in the config file. 
+## Configuration File
 
-##Example:
-`node: http://mynode.com:14265`
+The configuration can also be set in yaml formatted file. By default the configuration file from ~/.iritop is read. All configuration parameters can be provided in the config file.
 
+File should be in `yaml` format. Example:
+
+```
+node: http://mynode.com:14265
+poll_delay: 2
+blink_delay: 0.3
+```
 
 Use 'q' to exit from the tool.
-
-##Prerequisites:
-- Python 2 or 3
-- Urllib2 (pip install urllib2)
-- Blessed (pip install blessed)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+blessed>=1.15.0
+PyYAML>=3.12
+urllib3>=1.22


### PR DESCRIPTION
Support both python 2 and 3:
- Use urllib3 instead of urllib2
- Don't use version attribute in argparse (not supported in python 3)
- Error out with message for invalid yaml in configuration file
- Add requirements.txt file, add instructions in README.md