### PR TITLE
Fix missing locales on some systems

### DIFF
--- a/iritop.py
+++ b/iritop.py
@@ -8,7 +8,7 @@ import time
 import json
 import yaml
 import random
-from os import path
+from os import (path, environ)
 from curses import wrapper
 
 
@@ -171,6 +171,11 @@ def main():
     except Exception as e:
         sys.stderr.write("Error parsing arguments: %s\n" % e)
         sys.exit(1)
+
+    # Force set locale to ensure blessed term
+    # also works when those are missing
+    environ['LC_ALL'] = 'en_US.UTF-8'
+    environ['LC_CTYPE'] = 'en_US.UTF-8'
 
     iri_top = IriTop(args)
     wrapper(iri_top.run)


### PR DESCRIPTION
A user reported having this error:
```sh
Traceback (most recent call last):
  File "/usr/bin/iritop", line 582, in <module>
    main()
  File "/usr/bin/iritop", line 175, in main
    iri_top = IriTop(args)
  File "/usr/bin/iritop", line 231, in __init__
    self.term = Terminal()
  File "/usr/local/lib/python2.7/dist-packages/blessed/terminal.py", line 229, in __init__
    self.__init__keycodes()
  File "/usr/local/lib/python2.7/dist-packages/blessed/terminal.py", line 287, in __init__keycodes
    locale.setlocale(locale.LC_ALL, '')
  File "/usr/lib/python2.7/locale.py", line 581, in setlocale
    return _setlocale(category, locale)
locale.Error: unsupported locale setting
```

After having set ENVs:
```sh
export LC_ALL="en_US.UTF-8"
export LC_CTYPE="en_US.UTF-8"
```
There was no error.

This PR force sets those environment variables. Was tested by the user who originally reported this and seems this works.
