### PR TITLE
Encode properly, add tests for authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,4 +59,6 @@ File should be in `yaml` format. Example:
 node: http://mynode.com:14265
 poll_delay: 2
 blink_delay: 0.3
+username: admin
+password: verySecret123
 ```

--- a/tests/test_iritop.py
+++ b/tests/test_iritop.py
@@ -5,6 +5,7 @@ import logging
 import time
 import json
 import sys
+from functools import wraps
 from contextlib import (contextmanager, closing)
 
 
@@ -102,6 +103,18 @@ class TestArgParser(unittest.TestCase):
         with self.assertRaises(IOError):
             self.set_new_args(['--config=unknown.yml'])
 
+    def test_password_and_username(self):
+        """
+        Test username set but not password
+        """
+        with self.assertRaises(SystemExit):
+            LOG.debug("Testing only username passed")
+            self.set_new_args(['--username=nobody'])
+
+        with self.assertRaises(SystemExit):
+            LOG.debug("Testing only password passed")
+            self.set_new_args(['--password=secret'])
+
 
 class TestFetchData(unittest.TestCase):
 
@@ -114,6 +127,8 @@ class TestFetchData(unittest.TestCase):
             'blink_delay': 0.5,
             'obscure_address': False,
             'test': False,  # Remove?
+            'password': 'secret',
+            'username': 'nobody'
         }
 
         """ Get free port and set node address """
@@ -176,11 +191,45 @@ def is_open(ip, port):
         return False
 
 
-""" Handler for HTTP Server requests """
+def check_auth(func):
+    @wraps(func)
+    def wrapped(inst, *args, **kw):
 
+        # nobody:secret base64 encoded
+        if (inst.headers.get('Authorization') ==
+             'Basic bm9ib2R5OnNlY3JldA=='):
+
+            """ Allow if Authorization successful """
+            LOG.debug("Client authenticated: %s" %
+                      inst.client_address[0])
+
+            return func(inst, *args, **kw)
+
+        else:
+            """ Deny on wrong user:password """
+            return inst.refuse(address=inst.client_address[0],
+                               reason='Failed authentication',
+                               code=403)
+    return wrapped
+
+
+""" Handler for HTTP Server requests """
 
 class HTTPHandler(BaseHTTPRequestHandler):
 
+    def refuse(self, address=None, reason=None, code=401):
+        LOG.warning("HTTP: Client refused with '%s': %s" %
+                    (reason, address))
+        response = {}
+        if address is not None:
+            response['unauthorized'] = address
+
+        if reason is not None:
+            response['reason'] = reason
+
+        self.do_response(response=response, code=401)
+
+    @check_auth
     def do_POST(self):
         """ Simple POST router """
         if self.path == '/':

--- a/tests/test_iritop.py
+++ b/tests/test_iritop.py
@@ -105,7 +105,7 @@ class TestArgParser(unittest.TestCase):
 
     def test_password_and_username(self):
         """
-        Test username set but not password
+        Test username set but not password and vice-versa
         """
         with self.assertRaises(SystemExit):
             LOG.debug("Testing only username passed")
@@ -190,7 +190,7 @@ def is_open(ip, port):
     except:
         return False
 
-
+""" Check authentication wrapper """
 def check_auth(func):
     @wraps(func)
     def wrapped(inst, *args, **kw):


### PR DESCRIPTION
* Add ability to authenticate with user and password
* Add tests for user/password and test webserver authentication
* Add example in config file (username and password) 
* Tested with python 2.7.5 and 3.6

Maybe worth noting that to enable authentication with IRI one should set that in iri.ini as follows:
```
REMOTE_AUTH = username:password
```
