### PR TITLE
Use safe loading in yaml to get rid of warning msg

### DIFF
--- a/iritop.py
+++ b/iritop.py
@@ -227,7 +227,7 @@ def url(url):
 def read_config(config_file):
     with open(config_file) as fh:
         try:
-            data = yaml.load(fh)
+            data = yaml.safe_load(fh)
         except yaml.parser.ParserError as e:
             raise Exception("Error parsing yaml configuration file '%s': %s" %
                             (config_file, e))


### PR DESCRIPTION
Fixes this warning:
```
/bin/iritop:230: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  data = yaml.load(fh)
```