### PR TITLE
Add toggle address/domain names

### DIFF
--- a/iritop.py
+++ b/iritop.py
@@ -367,6 +367,11 @@ class IriTop:
             return True
         return False
 
+    def _missing_address(self, neighbor):
+        if 'address' not in neighbor or neighbor['address'] == "":
+            return True
+        return False
+
     def run(self, stdscr):
 
         """ Clear the screen on start """
@@ -459,7 +464,7 @@ class IriTop:
                     tlast = int(time.time())
 
                     for neighbor in neighbors:
-                        if 'address' not in neighbor:
+                        if self._missing_address(neighbor):
                             continue
                         for txkey in self.txkeys[1:]:
                             if txkey['key'] not in neighbor:
@@ -470,7 +475,7 @@ class IriTop:
                     # Keep history of tx
                     tx_history = {}
                     for neighbor in neighbors:
-                        if 'address' not in neighbor:
+                        if self._missing_address(neighbor):
                             continue
                         for txkey in self.txkeys[1:]:
                             self.historizer(txkey['keyshort'],
@@ -484,7 +489,7 @@ class IriTop:
 
                 if val.lower() == 'b':
                     for neighbor in neighbors:
-                        if 'address' not in neighbor:
+                        if self._missing_address(neighbor):
                             continue
                         for txkey in self.txkeys[1:]:
                             self.baseline[self.getBaselineKey(neighbor,
@@ -504,7 +509,7 @@ class IriTop:
                       self.term.black_on_cyan(s.rjust(6)))
 
                 for neighbor in neighbors:
-                    if 'address' not in neighbor:
+                    if self._missing_address(neighbor):
                         continue
                     for txkey in self.txkeys[1:]:
                         key = self.getBaselineKey(neighbor, txkey['keyshort'])
@@ -729,7 +734,7 @@ class IriTop:
 
         # Show Neighbors
         for neighbor in ordered_neighbors:
-            if 'address' not in neighbor:
+            if self._missing_address(neighbor):
                 continue
             self.show_neighbor(row, neighbor, cwl, cw, height)
             row += 1

--- a/iritop.py
+++ b/iritop.py
@@ -748,11 +748,13 @@ class IriTop:
 
         if self.show_domains is True and 'domain' in neighbor:
             # Domain doesn't contain port, therefore has to be appended
-            _address = neighbor['domain'] + ':' + neighbor['address'].split(':')[1]
+            _address = neighbor['domain'] + ':' \
+                                          + neighbor['address'].split(':')[1]
         else:
             _address = neighbor['address']
 
-        neighbor['addr'] = self.showAddress(neighbor['connectionType'] + "://" + _address)
+        neighbor['addr'] = self.showAddress(neighbor['connectionType']
+                                            + "://" + _address)
 
         # Create display string
         for txkey in self.txkeys[1:]:

--- a/iritop.py
+++ b/iritop.py
@@ -14,7 +14,7 @@ from os import (path, environ, getloadavg, getenv)
 from curses import wrapper
 
 
-__VERSION__ = '0.5.5'
+__VERSION__ = '0.5.6'
 
 """\
 Simple Iota IRI Node Monitor
@@ -117,6 +117,9 @@ def parse_args():
 
     parser.add_argument("-P", "--password", type=str,
                         help="IRI Password if required.")
+
+    parser.add_argument("-d", "--show-domains", action='store_true',
+                        help="Display domain names.")
 
     parser.add_argument("-s", "--sort", type=int,
                         help="Sort column # (-# for reverse sorting)")
@@ -332,6 +335,7 @@ class IriTop:
         self.sortorder = None
         self.mss_0 = ""
         self.prev_ms_start = 0
+        self.show_domains = args.show_domains
 
         # Initiate column sort
         if args.sort:
@@ -387,6 +391,10 @@ class IriTop:
                 random.seed(self.randSeed)
 
                 val = self.term.inkey(timeout=self.blink_delay)
+
+                # Toggle domain names
+                if val.lower() == 'n':
+                    self.show_domains = not self.show_domains
 
                 # Sort mode detection
                 if val.lower() == 's':
@@ -738,8 +746,13 @@ class IriTop:
                       column_width, height):
         global ITER
 
-        neighbor['addr'] = self.showAddress(neighbor['connectionType'] +
-                                            "://" + neighbor['address'])
+        if self.show_domains is True and 'domain' in neighbor:
+            # Domain doesn't contain port, therefore has to be appended
+            _address = neighbor['domain'] + ':' + neighbor['address'].split(':')[1]
+        else:
+            _address = neighbor['address']
+
+        neighbor['addr'] = self.showAddress(neighbor['connectionType'] + "://" + _address)
 
         # Create display string
         for txkey in self.txkeys[1:]:

--- a/iritop.py
+++ b/iritop.py
@@ -459,6 +459,8 @@ class IriTop:
                     tlast = int(time.time())
 
                     for neighbor in neighbors:
+                        if 'address' not in neighbor:
+                            continue
                         for txkey in self.txkeys[1:]:
                             if txkey['key'] not in neighbor:
                                 neighbor[txkey['key']] = 0
@@ -468,6 +470,8 @@ class IriTop:
                     # Keep history of tx
                     tx_history = {}
                     for neighbor in neighbors:
+                        if 'address' not in neighbor:
+                            continue
                         for txkey in self.txkeys[1:]:
                             self.historizer(txkey['keyshort'],
                                             txkey['key'],
@@ -480,6 +484,8 @@ class IriTop:
 
                 if val.lower() == 'b':
                     for neighbor in neighbors:
+                        if 'address' not in neighbor:
+                            continue
                         for txkey in self.txkeys[1:]:
                             self.baseline[self.getBaselineKey(neighbor,
                                           txkey['keyshort'])] = \
@@ -498,6 +504,8 @@ class IriTop:
                       self.term.black_on_cyan(s.rjust(6)))
 
                 for neighbor in neighbors:
+                    if 'address' not in neighbor:
+                        continue
                     for txkey in self.txkeys[1:]:
                         key = self.getBaselineKey(neighbor, txkey['keyshort'])
                         if key not in self.baseline:
@@ -721,6 +729,8 @@ class IriTop:
 
         # Show Neighbors
         for neighbor in ordered_neighbors:
+            if 'address' not in neighbor:
+                continue
             self.show_neighbor(row, neighbor, cwl, cw, height)
             row += 1
 
@@ -733,6 +743,7 @@ class IriTop:
                     "Q to exit - "
                     "B to reset tx to a zero baseline - "
                     "O to obscure addresses - "
+                    "N to toggle domain names - "
                     "S# to sort column".ljust(width)))
 
         ITER += 1

--- a/tests/test_iritop.py
+++ b/tests/test_iritop.py
@@ -158,7 +158,8 @@ class TestFetchData(unittest.TestCase):
             'test': False,  # Remove?
             'password': 'secret',
             'username': 'nobody',
-            'sort': 3
+            'sort': 3,
+            'show_domains': False
         }
 
         """ Get free port and set node address """
@@ -280,6 +281,8 @@ class Neighbor:
     def __init__(self, count):
         self.neighbor_data = {
             "address": "someneighbor%d:%d" % (count, random.randint(21600, 25600)),
+            "domain": "testing.iota%d.io" % (count),
+            "connected": True,
             "connectionType": self.protocol[random.randint(0, 1)],
             "numberOfAllTransactions": random.randint(100000, 200000),
             "numberOfInvalidTransactions": random.randint(0, 3),

--- a/tests/test_iritop.py
+++ b/tests/test_iritop.py
@@ -295,6 +295,7 @@ class Neighbor:
     def _increment_data(self):
         self.neighbor_data = {
             "address": self.neighbor_data['address'],
+            "domain": self.neighbor_data['domain'],
             "connectionType": self.neighbor_data['connectionType'],
             "numberOfAllTransactions": random.randint(
                 self.neighbor_data['numberOfAllTransactions'] + 10,


### PR DESCRIPTION
Since IRI 1.8.0 a new field has been introduced to the output of getNeighbors: `domain`.
This PR allows a user to toggle (or initially run) IRItop to display domainnames or addresses.
If the field doesn't exist, it will keep the `address` field displayed.